### PR TITLE
Fix error in update_blog.yml

### DIFF
--- a/.github/workflows/update_blog.yml
+++ b/.github/workflows/update_blog.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         git config --global user.name 'github-actions[bot]'
         git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-        git push https://${{ secrets.GH_PAT }}@github.com/mInsOng9/velog.git
+        git push https://${{ secrets.GH_PAT }}@github.com/mInsOng9/velog_minii
 
     - name: Set up Python
       uses: actions/setup-python@v2


### PR DESCRIPTION
Error :
Run git config --global user.name 'github-actions[bot]'
  git config --global user.name 'github-actions[bot]'
  git config --global user.email 'github-actions[bot]@users.noreply.github.com'
  git push https://@github.com/mInsOng9/velog.git
  shell: /usr/bin/bash -e {0}
remote: Repository not found.
fatal: repository 'https://github.com/mInsOng9/velog.git/' not found Error: Process completed with exit code 128.

Solution 01 : 
 - Double-check the repository URL. Change 'https://github.com/mInsOng9/velog.git/' to https://github.com/mInsOng9/velog_minii'